### PR TITLE
fix opinion base

### DIFF
--- a/dmas/agent.py
+++ b/dmas/agent.py
@@ -1,18 +1,19 @@
 import random
 from statistics import mode
 
-class Agent:
 
+class Agent:
     # attributes
     opinion = None  # the current belief of the agent (-1: false, 0:neutral, 1: true) (can become a list later for multiple news)
-    opinion_base = []  # The opinions that the agent heard from other persons
+    opinion_base = {}  # The opinions that the agent heard from other persons
     scepticism = None  # percent chance to change opinion when receives a different opinion
 
     # initializer
-    def __init__(self, opinion, scepticism):
+    def __init__(self, opinion, scepticism, num_agents):
         self.scepticism = scepticism
         self.opinion = opinion
-
+        # the agent initially thinks every other agent is neutral until they get called by them
+        self.opinion_base = {key: 0 for key in range(num_agents)}
 
     # evaluate new opinion from discussion
     def evaluate_opinion(self, new_opinion):
@@ -24,11 +25,13 @@ class Agent:
         # if the agent is either a liar or an expert they are 'stubborn' and don't change their opinion at all
         if self.scepticism == 1:
             pass
-        # in case there is a tie between "true" and "false" information
-        if self.opinion_base.count(1) == self.opinion_base.count(-1):
-            # then the agent takes on the last opinion they heard with the probability of 1 - skepticism
-            if random.uniform(0.0, 1.0) > self.scepticism:
-                self.opinion = self.opinion_base[-1]
-        # if there is no tie, we just take the mode
         else:
-           self.opinion = mode(self.opinion_base)
+            opinion_base = [value for value in self.opinion_base.values() if value != 0]
+            # in case there is a tie between "true" and "false" information
+            if opinion_base.count(1) == opinion_base.count(-1):
+                # then the agent takes on the last opinion they heard with the probability of 1 - skepticism
+                if random.uniform(0.0, 1.0) > self.scepticism:
+                    self.opinion = -1 * self.opinion  # this flips the current opinion to the one that caused the tie
+            # if there is no tie, we just take the mode
+            else:
+                self.opinion = mode(opinion_base)

--- a/dmas/environment.py
+++ b/dmas/environment.py
@@ -47,7 +47,7 @@ class Environment:
         for number in range(self.num_agents):
             # agents are initially generated neutral and
             # their scepticism follows a normal distribution around the average scepticism level
-            list_of_agents.append(agent.Agent(0, random.gauss(0.5, 0.1)))
+            list_of_agents.append(agent.Agent(0, random.gauss(0.5, 0.1), self.num_agents))
         # assign opinions to agents
         agent_indexes = random.sample(range(len(list_of_agents)), k=self.num_liars + self.num_experts)
         # declare liars & experts
@@ -103,7 +103,7 @@ class Environment:
             # agent_a is the sender and agent_b the receiver
             # neutral opinions don't spread
             if agent_a.opinion != 0:
-                agent_b.opinion_base.append(agent_a.opinion)
+                agent_b.opinion_base[self.agent_list.index(agent_a)] = agent_a.opinion
                 agent_b.form_opinion()
             self.exchange_phonebooks(agent_a, agent_b)
 


### PR DESCRIPTION
Instead of appending the opinion simply to a list, the agent now has a dictionary so that they know which opinion belongs to which agent. this way we also have a stop condition (when each agent has heard the opinion of each other agent